### PR TITLE
Update NET Core projects

### DIFF
--- a/LimeBean.NetCore/LimeBean.Tests/project.json
+++ b/LimeBean.NetCore/LimeBean.Tests/project.json
@@ -7,16 +7,16 @@
     "dependencies": {
         "Microsoft.NETCore.App": {
             "type": "platform",
-            "version": "1.0.0-rc2-*"
+            "version": "1.0.0"
         },
         "LimeBean": {
             "target": "project"
         },
-        "System.Data.SqlClient": "4.1.0-rc2-*",
-        "Microsoft.Data.SQLite": "1.0.0-rc2-final",
+        "System.Data.SqlClient": "4.1.0",
+        "Microsoft.Data.SQLite": "1.0.0",
         "Npgsql": "3.1.3",
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-rc2-*"
+        "dotnet-test-xunit": "2.2.0-preview2-*"
     },
 
     "testRunner": "xunit",

--- a/LimeBean.NetCore/LimeBean/project.json
+++ b/LimeBean.NetCore/LimeBean/project.json
@@ -1,5 +1,5 @@
 {
-    "name": "%lime_name%",
+    "name": "LimeBean",
     "version": "0.0",
     "authors": [ "%lime_author%" ],
     "copyright": "%lime_copyright%",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,8 @@ services:
 
 before_build:
   # Install dotnet cli
-  - ps: iex ((New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/Nick-Lucas/cli/91a985ebd0a70c5150135db0a15223f229cb1a34/scripts/obtain/dotnet-install.ps1'))
+  - appveyor DownloadFile https://raw.githubusercontent.com/dotnet/cli/v1.0.0-preview2/scripts/obtain/dotnet-install.ps1
+  - powershell -File dotnet-install.ps1
   - set PATH=%PATH%;%LOCALAPPDATA%\Microsoft\dotnet
   - dotnet --version
 

--- a/write-meta.ps1
+++ b/write-meta.ps1
@@ -15,7 +15,6 @@ if ($tag -match '^v?(([.\d]+)[\w-]*)$')  {
     $meta_version_full = $meta_version_numeric
 }
 
-$meta_name = "LimeBean"
 $meta_description = "RedBeanPHP-inspired data access layer"
 $meta_author = "Nick Lucas"
 $meta_copyright = "Copyright (c) 2014-2016 Aleksey Martynov, 2016-$(get-date -format yyyy) $meta_author"
@@ -28,7 +27,6 @@ $meta_license_url = "https://raw.githubusercontent.com/Nick-Lucas/LimeBean/maste
     (Get-Content $path) | %{
         $_  -replace '(AssemblyVersion.+?")[^"]+', "`${1}$meta_version_numeric" `
             -replace '("version":.+?")[^"]+', "`${1}$meta_version_full" `
-            -replace '%lime_name%', $meta_name `
             -replace '%lime_description%', $meta_description `
             -replace '%lime_author%', $meta_author `
             -replace '%lime_copyright%', $meta_copyright `


### PR DESCRIPTION
* Remove the use of `%lime_name%` placeholder for the `name` attr because it defines the assembly name, and breaks local NET Core builds
* Use 1.0.0 platform and deps, and 1.0.0-preview2 tooling for the test project ([announced yesterday](https://blogs.msdn.microsoft.com/dotnet/2016/06/27/announcing-net-core-1-0/))
* Use the official preview2 installer on appveyor